### PR TITLE
Add ray tracing verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# stlgen
+# STL Generator
+
+This repository contains utilities to convert images into 3D printable STL files.
+
+## disk_shadow_stl_generator.py
+
+`disk_shadow_stl_generator.py` creates a round plate with a central hole large
+enough for an E27 bulb. The relief heights on the plate are derived from a
+provided grayscale image so that illuminated shadows reproduce the original
+picture.
+
+Basic usage:
+```
+python disk_shadow_stl_generator.py input.png output.stl \
+    --outer_radius 60 --hole_radius 20
+```
+
+The script depends on `numpy` and `Pillow` being available in the Python
+environment.
+
+## raytrace_verify.py
+
+`raytrace_verify.py` performs a minimal ray tracing step to validate that the
+generated STL actually casts the intended shadow. It places a point light in the
+center of the hole and renders both the resulting shadow on a plane and an
+angled view of the geometry.
+
+Example:
+
+```
+python raytrace_verify.py output.stl --shadow_output shadow.png --render_output render.png
+```
+
+Both scripts require `numpy` and `Pillow` to run.
+

--- a/disk_shadow_stl_generator.py
+++ b/disk_shadow_stl_generator.py
@@ -1,0 +1,102 @@
+import math
+from typing import List, Tuple
+
+import numpy as np
+import struct
+from PIL import Image
+
+
+Vertex = Tuple[float, float, float]
+Face = Tuple[Vertex, Vertex, Vertex]
+
+def create_cube(x: float, y: float, z: float, size: float, height: float) -> List[Face]:
+    p = [
+        (x, y, z),
+        (x + size, y, z),
+        (x + size, y + size, z),
+        (x, y + size, z),
+        (x, y, z + height),
+        (x + size, y, z + height),
+        (x + size, y + size, z + height),
+        (x, y + size, z + height),
+    ]
+    return [
+        (p[0], p[3], p[1]), (p[1], p[3], p[2]),
+        (p[4], p[5], p[7]), (p[5], p[6], p[7]),
+        (p[0], p[1], p[4]), (p[1], p[5], p[4]),
+        (p[1], p[2], p[5]), (p[2], p[6], p[5]),
+        (p[2], p[3], p[6]), (p[3], p[7], p[6]),
+        (p[3], p[0], p[7]), (p[0], p[4], p[7]),
+    ]
+
+def _normal(v1: Vertex, v2: Vertex, v3: Vertex) -> Tuple[float, float, float]:
+    ux, uy, uz = (v2[0] - v1[0], v2[1] - v1[1], v2[2] - v1[2])
+    vx, vy, vz = (v3[0] - v1[0], v3[1] - v1[1], v3[2] - v1[2])
+    nx = uy * vz - uz * vy
+    ny = uz * vx - ux * vz
+    nz = ux * vy - uy * vx
+    length = math.sqrt(nx * nx + ny * ny + nz * nz) or 1.0
+    return nx / length, ny / length, nz / length
+
+
+def write_binary_stl(faces: List[Face], filename: str) -> None:
+    with open(filename, "wb") as f:
+        header = b"Created by disk_shadow_generator".ljust(80, b" ")
+        f.write(header)
+        f.write(len(faces).to_bytes(4, byteorder="little"))
+        for v1, v2, v3 in faces:
+            nx, ny, nz = _normal(v1, v2, v3)
+            f.write(struct.pack("<3f", nx, ny, nz))
+            for v in (v1, v2, v3):
+                f.write(struct.pack("<3f", *v))
+            f.write((0).to_bytes(2, byteorder="little"))
+
+def image_to_shadow_disk(
+    image_path: str,
+    output_path: str,
+    outer_radius: float = 50.0,
+    hole_radius: float = 20.0,
+    base_thickness: float = 1.0,
+    max_relief: float = 5.0,
+    resolution: int = 200,
+) -> None:
+    img = Image.open(image_path).convert("L")
+    img = img.resize((resolution, resolution))
+    pixels = np.array(img)
+    pixels = 255 - pixels
+
+    pixel_size = 2 * outer_radius / resolution
+    faces: List[Face] = []
+    for i in range(resolution):
+        x = i * pixel_size - outer_radius
+        for j in range(resolution):
+            y = j * pixel_size - outer_radius
+            r = math.hypot(x + pixel_size / 2, y + pixel_size / 2)
+            if hole_radius <= r <= outer_radius:
+                h = base_thickness + (pixels[j, i] / 255.0) * max_relief
+                faces.extend(create_cube(x, y, 0.0, pixel_size, h))
+    write_binary_stl(faces, output_path)
+    print(f"STL saved to {output_path}")
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Generate disk shadow STL")
+    parser.add_argument("image", help="input image file")
+    parser.add_argument("output", help="output STL file")
+    parser.add_argument("--outer_radius", type=float, default=50.0)
+    parser.add_argument("--hole_radius", type=float, default=20.0)
+    parser.add_argument("--base_thickness", type=float, default=1.0)
+    parser.add_argument("--max_relief", type=float, default=5.0)
+    parser.add_argument("--resolution", type=int, default=200)
+    args = parser.parse_args()
+
+    image_to_shadow_disk(
+        args.image,
+        args.output,
+        outer_radius=args.outer_radius,
+        hole_radius=args.hole_radius,
+        base_thickness=args.base_thickness,
+        max_relief=args.max_relief,
+        resolution=args.resolution,
+    )

--- a/raytrace_verify.py
+++ b/raytrace_verify.py
@@ -1,0 +1,123 @@
+import math
+import struct
+from typing import Tuple, List
+
+import numpy as np
+from PIL import Image
+
+Vector = np.ndarray
+Triangle = Tuple[Vector, Vector, Vector]
+
+def load_binary_stl(filename: str) -> List[Triangle]:
+    with open(filename, 'rb') as f:
+        f.read(80)  # header
+        count = struct.unpack('<I', f.read(4))[0]
+        tris = []
+        for _ in range(count):
+            data = struct.unpack('<12fH', f.read(50))
+            v1 = np.array(data[3:6])
+            v2 = np.array(data[6:9])
+            v3 = np.array(data[9:12])
+            tris.append((v1, v2, v3))
+    return tris
+
+def ray_triangle_intersect(orig: Vector, dir: Vector, tri: Triangle) -> float:
+    v0, v1, v2 = tri
+    eps = 1e-6
+    edge1 = v1 - v0
+    edge2 = v2 - v0
+    h = np.cross(dir, edge2)
+    a = np.dot(edge1, h)
+    if -eps < a < eps:
+        return math.inf
+    f = 1.0 / a
+    s = orig - v0
+    u = f * np.dot(s, h)
+    if u < 0.0 or u > 1.0:
+        return math.inf
+    q = np.cross(s, edge1)
+    v = f * np.dot(dir, q)
+    if v < 0.0 or u + v > 1.0:
+        return math.inf
+    t = f * np.dot(edge2, q)
+    if t > eps:
+        return t
+    return math.inf
+
+def make_shadow_image(tris: List[Triangle], light: Vector, plane_z: float,
+                       size: float, resolution: int) -> Image.Image:
+    half = size / 2.0
+    img = np.zeros((resolution, resolution), dtype=np.uint8) + 255
+    for iy in range(resolution):
+        y = (iy / (resolution - 1) - 0.5) * size
+        for ix in range(resolution):
+            x = (ix / (resolution - 1) - 0.5) * size
+            target = np.array([x, y, plane_z])
+            dir = target - light
+            dist = np.linalg.norm(dir)
+            dir /= dist
+            blocked = False
+            for tri in tris:
+                t = ray_triangle_intersect(light, dir, tri)
+                if t < dist:
+                    blocked = True
+                    break
+            if blocked:
+                img[iy, ix] = 0
+    return Image.fromarray(img)
+
+def make_render_image(tris: List[Triangle], light: Vector, camera: Vector,
+                      resolution: int, fov: float = math.pi / 3) -> Image.Image:
+    aspect = 1.0
+    screen_dist = 1.0 / math.tan(fov / 2.0)
+    img = np.zeros((resolution, resolution), dtype=np.uint8)
+    for iy in range(resolution):
+        py = (1 - 2 * (iy + 0.5) / resolution)
+        for ix in range(resolution):
+            px = (2 * (ix + 0.5) / resolution - 1) * aspect
+            dir = np.array([px, py, -screen_dist])
+            dir = dir / np.linalg.norm(dir)
+            dir_world = dir  # camera at origin looking along -z
+            orig = camera
+            nearest_t = math.inf
+            nearest_tri = None
+            for tri in tris:
+                t = ray_triangle_intersect(orig, dir_world, tri)
+                if t < nearest_t:
+                    nearest_t = t
+                    nearest_tri = tri
+            if nearest_tri is not None:
+                point = orig + dir_world * nearest_t
+                normal = np.cross(nearest_tri[1]-nearest_tri[0], nearest_tri[2]-nearest_tri[0])
+                normal = normal / (np.linalg.norm(normal) or 1.0)
+                light_dir = light - point
+                light_dir /= np.linalg.norm(light_dir)
+                intensity = max(0.0, np.dot(normal, light_dir))
+                img[iy, ix] = int(255 * intensity)
+    return Image.fromarray(img)
+
+def verify(stl_path: str, shadow_output: str, render_output: str,
+           plane_z: float = 100.0, size: float = 100.0,
+           resolution: int = 256) -> None:
+    tris = load_binary_stl(stl_path)
+    light = np.array([0.0, 0.0, 0.0])
+    cam = np.array([0.0, 0.0, 80.0])
+    shadow = make_shadow_image(tris, light, plane_z, size, resolution)
+    shadow.save(shadow_output)
+    render = make_render_image(tris, light, cam, resolution)
+    render.save(render_output)
+    print(f"Shadow saved to {shadow_output}")
+    print(f"Render saved to {render_output}")
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description='Raytrace STL to verify shadow')
+    parser.add_argument('stl', help='input STL file')
+    parser.add_argument('--shadow_output', default='shadow.png')
+    parser.add_argument('--render_output', default='render.png')
+    parser.add_argument('--plane_z', type=float, default=100.0)
+    parser.add_argument('--size', type=float, default=100.0)
+    parser.add_argument('--resolution', type=int, default=256)
+    args = parser.parse_args()
+    verify(args.stl, args.shadow_output, args.render_output,
+           plane_z=args.plane_z, size=args.size, resolution=args.resolution)


### PR DESCRIPTION
## Summary
- document new verification step in README
- add `raytrace_verify.py` for simple STL ray tracing

## Testing
- `python3 -m py_compile disk_shadow_stl_generator.py raytrace_verify.py shadow_stl_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_687c394299188322a4b18e317e10728d