### PR TITLE
Add mixed shape support for disk shadow generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ python disk_shadow_stl_generator.py input.png output.stl \
     --outer_radius 60 --hole_radius 20
 ```
 
+You can optionally choose different element shapes that build up the relief. Use
+`--shape cube` (default), `--shape cylinder`, `--shape pyramid` or
+`--shape mixed` to randomly mix them across the disk.
+
 The script depends on `numpy` and `Pillow` being available in the Python
 environment.
 


### PR DESCRIPTION
## Summary
- allow selecting cube, pyramid or cylinder elements to build the disc
- implement `--shape` option in `disk_shadow_stl_generator.py`
- document new option in README

## Testing
- `python -m py_compile disk_shadow_stl_generator.py shadow_stl_generator.py raytrace_verify.py`
- *(failed: `pip install pillow` due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687c48f94d1483229ef73756a894c35f